### PR TITLE
Add `StoryblokClient::withHttpClient()` to be able to use a different http-client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "psr/log": "^3.0",
         "symfony/cache": "^7.0",
         "symfony/cache-contracts": "^3.5",
+        "symfony/deprecation-contracts": "^2.5|^3.5",
         "symfony/http-client": "^6.0 || ^7.0",
         "thecodingmachine/safe": "^2.0",
         "webmozart/assert": "^1.11"

--- a/src/StoryblokClient.php
+++ b/src/StoryblokClient.php
@@ -41,9 +41,20 @@ final class StoryblokClient implements StoryblokClientInterface
         ?HttpClientInterface $storyblokClient = null,
         private LoggerInterface $logger = new NullLogger(),
     ) {
+        if ($storyblokClient instanceof HttpClientInterface) {
+            trigger_deprecation('sensiolabs-de/storyblok-api', '2.4', 'The "$storyblokClient" argument is deprecated and will be removed in 3.0. Use "withHttpClient()" instead.');
+        }
+
         $this->client = $storyblokClient ?? HttpClient::createForBaseUri($baseUri);
         $this->token = TrimmedNonEmptyString::fromString($token, '$token must not be an empty string')->toString();
         $this->timeout = $timeout;
+    }
+
+    public function withHttpClient(HttpClientInterface $client): self
+    {
+        $this->client = $client;
+
+        return $this;
     }
 
     public function request(string $method, string $url, array $options = []): ResponseInterface

--- a/tests/Integration/StoryblokClientTest.php
+++ b/tests/Integration/StoryblokClientTest.php
@@ -53,7 +53,6 @@ final class StoryblokClientTest extends TestCase
         return new StoryblokClient(
             baseUri: 'https://api.storyblok.com/',
             token: 'test-token',
-            storyblokClient: new MockHttpClient($response, 'https://api.storyblok.com/'),
         );
     }
 }


### PR DESCRIPTION
* Deprecate passing an http-client via the constructor

I will create a follow-up PR, so that we can create a 3.0 version
