### PR TITLE
Enhancement: Introduce dedicated `StoryblokAssetsClient`

### DIFF
--- a/src/StoryblokAssetsClient.php
+++ b/src/StoryblokAssetsClient.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SensioLabs\Storyblok\Api;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class StoryblokAssetsClient implements StoryblokClientInterface
+{
+    public function __construct(
+        #[\SensitiveParameter]
+        private string $token,
+        private StoryblokClientInterface $client,
+    ) {
+    }
+
+    public function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        return $this->client->request(
+            $method,
+            $url,
+            array_replace_recursive($options, ['query' => ['token' => $this->token]]),
+        );
+    }
+}

--- a/tests/Integration/SpacesApiTest.php
+++ b/tests/Integration/SpacesApiTest.php
@@ -72,10 +72,16 @@ final class SpacesApiTest extends TestCase
      */
     public static function createClient(array $response): StoryblokClient
     {
-        return new StoryblokClient(
+        $client = new StoryblokClient(
             baseUri: 'https://example.com/',
             token: 'token',
-            storyblokClient: new MockHttpClient(new JsonMockResponse($response), 'https://api.storyblok.com/'),
         );
+
+        $client->withHttpClient(new MockHttpClient(
+            new JsonMockResponse($response),
+            'https://api.storyblok.com/',
+        ));
+
+        return $client;
     }
 }


### PR DESCRIPTION
I am targeting this PR in order to have a dedicated `StoryblokAssetsClient` to because it must have a different token than the normal Client.