### PR TITLE
Enhancement: Pass `version` for story requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
 
 $client = new StoryblokClient(/* ... */);
 
-$storiesApi = new StoriesApi($client, Version::Draft);
+$storiesApi = new StoriesApi($client, Version::Published);
 $response = $storiesApi->bySlug(
     locale: 'de',
     slug: '/my-story/',

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ $response = $storiesApi->all(locale: 'de');
 ```php
 use SensioLabs\Storyblok\Api\StoriesApi;
 use SensioLabs\Storyblok\Api\StoryblokClient;
-use SensioLabs\Storyblok\Api\Domain\Value\Dto\Pagination;
 use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
 
 $client = new StoryblokClient(/* ... */);
@@ -90,7 +89,6 @@ $response = $storiesApi->bySlug(
 ```php
 use SensioLabs\Storyblok\Api\StoriesApi;
 use SensioLabs\Storyblok\Api\StoryblokClient;
-use SensioLabs\Storyblok\Api\Domain\Value\Dto\Pagination;
 use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
 
 $client = new StoryblokClient(/* ... */);

--- a/README.md
+++ b/README.md
@@ -66,6 +66,43 @@ $storiesApi = new StoriesApi($client);
 $response = $storiesApi->all(locale: 'de');
 ```
 
+### Fetch by Version (`draft`, `published`)
+
+#### Global
+
+```php
+use SensioLabs\Storyblok\Api\StoriesApi;
+use SensioLabs\Storyblok\Api\StoryblokClient;
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Pagination;
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
+
+$client = new StoryblokClient(/* ... */);
+
+$storiesApi = new StoriesApi($client, Version::Draft);
+$response = $storiesApi->bySlug(
+    locale: 'de',
+    slug: '/my-story/',
+);
+```
+
+#### Method Call
+
+```php
+use SensioLabs\Storyblok\Api\StoriesApi;
+use SensioLabs\Storyblok\Api\StoryblokClient;
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Pagination;
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
+
+$client = new StoryblokClient(/* ... */);
+
+$storiesApi = new StoriesApi($client, Version::Draft);
+$response = $storiesApi->bySlug(
+    locale: 'de',
+    slug: '/my-story/',
+    version: Version::Draft, // This overrides the global "version"
+);
+```
+
 ### Pagination
 
 ```php

--- a/src/StoriesApi.php
+++ b/src/StoriesApi.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SensioLabs\Storyblok\Api;
 
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
 use SensioLabs\Storyblok\Api\Domain\Value\Id;
 use SensioLabs\Storyblok\Api\Domain\Value\Total;
 use SensioLabs\Storyblok\Api\Domain\Value\Uuid;
@@ -31,6 +32,7 @@ final class StoriesApi implements StoriesApiInterface
 
     public function __construct(
         private StoryblokClientInterface $client,
+        private Version $version = Version::Published,
     ) {
     }
 
@@ -69,7 +71,7 @@ final class StoriesApi implements StoriesApiInterface
         );
     }
 
-    public function bySlug(string $slug, string $language = 'default'): StoryResponse
+    public function bySlug(string $slug, string $language = 'default', ?Version $version = null): StoryResponse
     {
         Assert::stringNotEmpty($language);
         Assert::stringNotEmpty($slug);
@@ -77,13 +79,14 @@ final class StoriesApi implements StoriesApiInterface
         $response = $this->client->request('GET', \sprintf('%s/%s', self::ENDPOINT, $slug), [
             'query' => [
                 'language' => $language,
+                'version' => null !== $version ? $version->value : $this->version->value,
             ],
         ]);
 
         return new StoryResponse($response->toArray());
     }
 
-    public function byUuid(Uuid $uuid, string $language = 'default'): StoryResponse
+    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null): StoryResponse
     {
         Assert::stringNotEmpty($language);
 
@@ -91,19 +94,21 @@ final class StoriesApi implements StoriesApiInterface
             'query' => [
                 'language' => $language,
                 'find_by' => 'uuid',
+                'version' => null !== $version ? $version->value : $this->version->value,
             ],
         ]);
 
         return new StoryResponse($response->toArray());
     }
 
-    public function byId(Id $id, string $language = 'default'): StoryResponse
+    public function byId(Id $id, string $language = 'default', ?Version $version = null): StoryResponse
     {
         Assert::stringNotEmpty($language);
 
         $response = $this->client->request('GET', \sprintf('/v2/cdn/stories/%s', $id->value), [
             'query' => [
                 'language' => $language,
+                'version' => null !== $version ? $version->value : $this->version->value,
             ],
         ]);
 

--- a/src/StoriesApiInterface.php
+++ b/src/StoriesApiInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SensioLabs\Storyblok\Api;
 
+use SensioLabs\Storyblok\Api\Domain\Value\Dto\Version;
 use SensioLabs\Storyblok\Api\Domain\Value\Id;
 use SensioLabs\Storyblok\Api\Domain\Value\Uuid;
 use SensioLabs\Storyblok\Api\Request\StoriesRequest;
@@ -30,9 +31,9 @@ interface StoriesApiInterface
 
     public function allByContentType(string $contentType, ?StoriesRequest $request = null): StoriesResponse;
 
-    public function bySlug(string $slug, string $language = 'default'): StoryResponse;
+    public function bySlug(string $slug, string $language = 'default', ?Version $version = null): StoryResponse;
 
-    public function byUuid(Uuid $uuid, string $language = 'default'): StoryResponse;
+    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null): StoryResponse;
 
-    public function byId(Id $id, string $language = 'default'): StoryResponse;
+    public function byId(Id $id, string $language = 'default', ?Version $version = null): StoryResponse;
 }


### PR DESCRIPTION
I am targeting this branch because its BC.

This is required to be able to pass a version to item `GET` operations. For collection `GET` operation this was already covered by the Request Objects.